### PR TITLE
BUG: missing model file

### DIFF
--- a/pysatModelUtils/utils/match.py
+++ b/pysatModelUtils/utils/match.py
@@ -148,9 +148,13 @@ def collect_inst_model_pairs(start=None, stop=None, tinc=None, inst=None,
         mod_file = start.strftime(model_files)
 
         if path.isfile(mod_file):
-            mdata = model_load_rout(mod_file, start)
-            lon_high = float(mdata.coords[mod_lon_name].max())
-            lon_low = float(mdata.coords[mod_lon_name].min())
+            try:
+                mdata = model_load_rout(mod_file, start)
+                lon_high = float(mdata.coords[mod_lon_name].max())
+                lon_low = float(mdata.coords[mod_lon_name].min())
+            except Exception as err:
+                logger.warning("unable to load {:s}: {:}".format(mod_file, err))
+                mdata = None
         else:
             mdata = None
 


### PR DESCRIPTION
Routine previously could not handle a missing model file.  New try/except statement will allow matching to continue regardless of the exception thrown by
the user-supplied file loading module.

# Description

Addresses bug found in `pysat.mode_utils` that is fixed in https://github.com/pysat/pysat/pull/317

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested by running a period of time where some model files are missing.

**Test Configuration**:
* OS X Sierra
* python 2.7.15

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
