### PR TITLE
BUG: python 3.5 unit tests and xarray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,10 @@ before_install:
   - cd ./pysat
   - git checkout develop
   # set up data directory
-  - mkdir /home/travis/build/pysat/pysatData
+  - mkdir /home/travis/build/pysatData
   # install pysat
-  - cd /home/travis/build/pysat/pysat
   - python setup.py install >/dev/null
-  - cd /home/travis/build/pysat/pysatModelUtils
+  - cd ../pysatModelUtils
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_install:
   - pip install future
   - pip install matplotlib
   - pip install netCDF4
+  - pip install 'pandas<0.25'
+  - pip install xarray
   - pip install pysatCDF >/dev/null
   # Prepare modified pysat install
   - pip install numpy
@@ -26,7 +28,7 @@ before_install:
   - git clone https://github.com/pysat/pysat.git >/dev/null
   - echo 'installing pysat'
   - cd ./pysat
-  - git checkout no_sgp4
+  - git checkout develop
   # set up data directory
   - mkdir /home/travis/build/pysat/pysatData
   # install pysat


### PR DESCRIPTION
# Description

xarray 0.14.0 is not compatible with python 3.5.  This updates the environment setup in Travis CI to manually install both `xarray` and `pandas` (which is required by xarray and will create errors down the line if not installed manually in the environment).

Also updated the custom `pysat` install to develop since the no_sgp4 branch is merged there.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updates to Travis CI environment, so tested there.  Based on lessons learned from sami2py/sami2py#81 and pysat/pysatMissionPlanning#7.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
