### PR TITLE
TST: clean up pysat install on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,38 @@
+os: linux
 language: python
 dist: xenial
-matrix:
+jobs:
   include:
     - python: 2.7
-    - python: 3.5
     - python: 3.6
     - python: 3.7
+    - python: 3.8
 
+services: xvfb
 addons:
   apt:
     packages:
     - gfortran
-
+    
 before_install:
   - pip install pytest-cov
   - pip install coveralls
   - pip install future
-  - pip install matplotlib
-  - pip install netCDF4
+  - pip install numpy
   - pip install 'pandas<0.25'
   - pip install xarray
+  - pip install matplotlib
+  # Install pysatCDF and dump output
   - pip install pysatCDF >/dev/null
-
-  - pip install numpy
-  - pip install 'pysat>=2.1.0'
-# set up data directory
+  # Prepare pysat install from git
+  - cd ..
+  - git clone https://github.com/pysat/pysat.git >/dev/null
+  - cd ./pysat
+  # set up data directory
   - mkdir /home/travis/build/pysatData
+  # install pysat
+  - python setup.py install >/dev/null
+  - cd ../pysatModelUtils
 
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,20 +21,11 @@ before_install:
   - pip install 'pandas<0.25'
   - pip install xarray
   - pip install pysatCDF >/dev/null
-  # Prepare modified pysat install
-  - pip install numpy
-  - cd ..
-  - echo 'cloning pysat'
-  - git clone https://github.com/pysat/pysat.git >/dev/null
-  - echo 'installing pysat'
-  - cd ./pysat
-  - git checkout develop
-  # set up data directory
-  - mkdir /home/travis/build/pysatData
-  # install pysat
-  - python setup.py install >/dev/null
-  - cd ../pysatModelUtils
 
+  - pip install numpy
+  - pip install 'pysat>=2.1.0'
+# set up data directory
+  - mkdir /home/travis/build/pysatData
 
 install:
   - python setup.py install


### PR DESCRIPTION
# Description

Pysat 2.1.0 is now available via pip.  There is no longer a need for the custom pysat install, so the pysat family of codes is being upgraded to a "standard" installation through pip.  This will allow the `no_sgp4` branch of pysat to be deleted.

## Type of change

- Test environment update

# How Has This Been Tested?

Updates to Travis-CI environment, so tested there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
