### PR TITLE
ENH: limit downloads

### DIFF
--- a/pysatModelUtils/utils/match.py
+++ b/pysatModelUtils/utils/match.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 import datetime as dt
 import numpy as np
 from os import path
+from pandas import (DateOffset, date_range)
 
 import pysat
 
@@ -183,10 +184,13 @@ def collect_inst_model_pairs(start, stop, tinc, inst, inst_download_kwargs={},
         raise ValueError('Need routine to clean the instrument data')
 
     # Download the instrument data, if needed
-    # Could use some improvement, for not re-downloading times that you already
-    # have
     if (stop - start).days != len(inst.files[start:stop]):
-        inst.download(start=start, stop=stop, **inst_download_kwargs)
+        missing_times = [tt for tt in date_range(start, stop, freq='1D',
+                                                 closed='left')
+                         if tt not in inst.files[start:stop].index]
+        for tt in missing_times:
+            inst.download(start=tt, stop=tt+DateOffset(days=1),
+                          user=user, password=password)
 
     # Cycle through the times, loading the model and instrument data as needed
     istart = start


### PR DESCRIPTION
Limit instrument downloads when matching data by checking times against the
current file list.

The biggest flaw is that it keeps checking the database for periods when there are no files.  This isn't a huge issue for satellites (CINDI has only a few 'missing' files per year), but is a big issue for ISR data.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I added this change to reduce the time of my SAMI3 model validation runs and has been run for CINDI IVM and JRO ISR for multiple year-long runs.

**Test Configuration**:
* Operating system: OS X Sierra
* Version number: 2.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
