### PR TITLE
Tiegcm patch -- broken windows tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 [0.2.0] - 2022-XX-XX
 --------------------
+* Added support for access to TIEGCM models from the ICON mission
 * Documentation
    * Added badges and instructions for PyPi and Zenodo
 

--- a/pysatModels/tests/test_utils_extract.py
+++ b/pysatModels/tests/test_utils_extract.py
@@ -8,6 +8,7 @@
 import logging
 import numpy as np
 from packaging import version as pack_version
+import platform
 import pytest
 
 import pysat
@@ -471,6 +472,9 @@ class TestUtilsExtractInstModViewXarray(TestUtilsExtractInstThroughMod):
         return
 
 
+# TODO(#118): fix `instrument_altitude_to_model_pressure` for Windows env
+@pytest.mark.skipif(platform.system() == "Windows",
+                    reason="Broken on windows, see #118")
 @pytest.mark.skipif(pack_version.Version(pysat.__version__)
                     <= pack_version.Version('3.0.1'),
                     reason=''.join(('Requires test model in pysat ',
@@ -604,6 +608,9 @@ class TestUtilsAltitudePressure(object):
         return
 
 
+# TODO(#118): fix `instrument_altitude_to_model_pressure` for Windows env
+@pytest.mark.skipif(platform.system() == "Windows",
+                    reason="Broken on windows, see #118")
 @pytest.mark.skipif(pack_version.Version(pysat.__version__)
                     <= pack_version.Version('3.0.1'),
                     reason=''.join(('Requires test model in pysat ',


### PR DESCRIPTION
# Description

Addresses #118 (partial)

Adds a `skip`  for tests that are broken in a windows environment.  This should get the unit tests working again, though we probably need a warning in the function for windows or better documentation if 0.2.0 is released before this is fixed.

Also adds a changelog suggestion for the main PR.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

on github actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
