### PR TITLE
MAINT/BUG: GA updates, pandas 2.0+ compatibility

### DIFF
--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [push]
+on: [workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [workflow_dispatch]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -1,0 +1,33 @@
+# This workflow will install Python dependencies and the latest RC of pysatNASA from test pypi.
+# This test should be manually run before a pysatModels RC is officially approved and versioned.
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test install of latest RC from pip
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.10"]  # Keep this version at the highest supported Python version
+
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install standard dependencies
+      run: pip install -r requirements.txt
+
+    - name: Install pysatModels RC
+      run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysatModels
+
+    - name: Check that install imports correctly
+      run: python -c "import pysatModels"

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.10"]  # Keep this version at the highest supported Python version
+        python-version: ["3.8", "3.9", "3.10"]  # Keep this version at the highest supported Python version
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -29,5 +29,10 @@ jobs:
     - name: Install pysatModels RC
       run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysatModels
 
+    - name: Set up pysat
+      run: |
+        mkdir pysatData
+        python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
+
     - name: Check that install imports correctly
       run: python -c "import pysatModels"

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -35,4 +35,6 @@ jobs:
         python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
 
     - name: Check that install imports correctly
-      run: python -c "import pysatModels"
+      run: |
+        cd ..
+        python -c "import pysatModels; print(pysatModels.__version__)"

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -6,7 +6,7 @@
 
 name: Test with pysat ecosystem RCs
 
-on: [push]
+on: [workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -6,7 +6,7 @@
 
 name: Test with pysat ecosystem RCs
 
-on: [workflow_dispatch]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies (including the latest RC 
+# This workflow will install Python dependencies (including the latest RC
 # for pysat packages) and run tests for supported operating systems.
 # For more information see:
 # https://help.github.com/actions/language-and-framework-guides/
@@ -27,7 +27,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install RC package
-      run: pip install --no-deps -i https://test.pypi.org/simple/ ${{ matrix.rc-package }}
+      run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ ${{ matrix.rc-package }}
 
     - name: Install standard dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated NEP29 and GitHub actions versions
   * Added manual test for pysat and pysatNASA Release Candidates
   * Added manual test for pysatModels RC pip install
+  * Updated tests to new pysat and pytest standards
 * Documentation
   * Added badges and instructions for PyPi and Zenodo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Switched pydineof_dineof load code to use newer `pysat.utils.io.load_netcdf`
   * Updated NEP29 and GitHub actions versions
   * Added manual test for pysat and pysatNASA Release Candidates
+  * Added manual test for pysatModels RC pip install
 * Documentation
   * Added badges and instructions for PyPi and Zenodo
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the Space Physics community.  This module officially supports Python 3.6+.
 |   Common modules   | Community modules |
 | ------------------ | ----------------- |
 | numpy              | pyForecastTools   |
-| pandas             | pysat >= 3.0.4    |
+| pandas >= 1.4.0    | pysat >= 3.0.4    |
 | requests           | pysatNASA         |
 | scipy              |                   |
 | xarray             |                   |

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -235,7 +235,7 @@ class TestSAMILoadMultipleDays(object):
         assert meta_two_days == meta_one_days
 
         # Confirm time index information
-        assert data_two_days.indexes['time'].is_monotonic
+        assert data_two_days.indexes['time'].is_monotonic_increasing
         assert data_two_days.indexes['time'][0] >= test_date
         assert data_two_days.indexes['time'][0] < date
         assert data_two_days.indexes['time'][-1] > date

--- a/pysatModels/tests/test_utils_compare.py
+++ b/pysatModels/tests/test_utils_compare.py
@@ -11,7 +11,7 @@ import pysatModels.utils.compare as compare
 class TestUtilsCompare(object):
     """Unit tests for utils.compare."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
         coords = {"lat": np.arange(-90, 90, 10), "alt": np.arange(200, 800, 10)}
@@ -29,7 +29,7 @@ class TestUtilsCompare(object):
         self.out_units = dict()
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment after each method."""
 
         del self.dat_key, self.mod_key, self.units, self.pairs, self.input_args

--- a/pysatModels/tests/test_utils_match.py
+++ b/pysatModels/tests/test_utils_match.py
@@ -13,17 +13,18 @@ import pysatModels.utils.match as match
 class TestUtilsMatchCollectInstModPairs(object):
     """Unit tests for utils.match.collect_inst_model_pairs."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
-        self.inst = pysat.Instrument(platform='pysat', name='testing')
+        self.inst = pysat.Instrument(platform='pysat', name='testing',
+                                     use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.inst.load(date=self.stime)
         self.input_args = [self.stime, self.stime + dt.timedelta(days=1),
                            dt.timedelta(days=1), self.inst]
         self.ref_col = 'dummy1'
         self.model = pysat.Instrument(platform='pysat', name='testmodel',
-                                      tag='', num_samples=10)
+                                      tag='', num_samples=10, use_header=True)
         self.required_kwargs = {"model_load_kwargs":
                                 {"model_inst": self.model},
                                 "inst_clean_rout": lambda x: True,
@@ -37,7 +38,7 @@ class TestUtilsMatchCollectInstModPairs(object):
         self.out = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment after each method."""
 
         del self.input_args, self.required_kwargs, self.inst, self.model

--- a/pysatModels/utils/match.py
+++ b/pysatModels/utils/match.py
@@ -163,7 +163,7 @@ def collect_inst_model_pairs(start, stop, tinc, inst, inst_download_kwargs=None,
     if not skip_download and (stop
                               - start).days != len(inst.files[start:stop]):
         missing_times = [tt for tt in pds.date_range(start, stop, freq='1D',
-                                                     closed='left')
+                                                     inclusive='left')
                          if tt not in inst.files[start:stop].index]
         for tt in missing_times:
             inst.download(start=tt, stop=tt + pds.DateOffset(days=1),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 packaging
-pandas
+pandas >= 1.4.0
 pyForecastTools
 pysat >= 3.0.4
 pysatNASA

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,5 +6,5 @@ m2r2
 numpydoc
 pytest-cov
 pytest-ordering
-sphinx
+sphinx<7.0
 sphinx_rtd_theme

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 coveralls
 flake8
 flake8-docstrings
-hacking>=1.0
+hacking>=1.0,<6.0
 m2r2
 numpydoc
 pytest-cov


### PR DESCRIPTION
# Description

Updates GA environment to be compatible with latest environments.  Updates to pip usage for RC installs.

Version cap on hacking until E275 is cleaned up in code.

Updates pandas syntax removed in 2.0.0 (`is_monotonic` and `close` kwarg).

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

via pytest with pandas 2.0.0 installed.

**Test Configuration**:
* Operating system: Ventura
* Version number: Python 3.10.8
* pandas 2.0.1

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
