### PR TITLE
MAINT: testing standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added manual test for pysat and pysatNASA Release Candidates
   * Added manual test for pysatModels RC pip install
   * Updated tests to new pysat and pytest standards
-  * Added cap for pysatNASA
+  * Added a cap for pysatNASA
 * Documentation
   * Added badges and instructions for PyPi and Zenodo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added manual test for pysat and pysatNASA Release Candidates
   * Added manual test for pysatModels RC pip install
   * Updated tests to new pysat and pytest standards
+  * Added cap for pysatNASA
 * Documentation
   * Added badges and instructions for PyPi and Zenodo
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 pysatModels handles model-centric data loading through pysat and contains a
 variety of tools to perform model-data analysis, including model validation.
 
-Come join us on Slack! An invitation to the pysat workspace is available 
+Come join us on Slack! An invitation to the pysat workspace is available
 in the 'About' section of the
 [pysat GitHub Repository.](https://github.com/pysat/pysat)
 
@@ -27,13 +27,13 @@ examples on how to use the routines
 pysatModels uses common Python modules, as well as modules developed by and for
 the Space Physics community.  This module officially supports Python 3.6+.
 
-|   Common modules   | Community modules |
-| ------------------ | ----------------- |
-| numpy              | pyForecastTools   |
-| pandas >= 1.4.0    | pysat >= 3.0.4    |
-| requests           | pysatNASA         |
-| scipy              |                   |
-| xarray             |                   |
+|   Common modules   | Community modules  |
+| ------------------ | ------------------ |
+| numpy              | pyForecastTools    |
+| pandas >= 1.4.0    | pysat >= 3.0.4     |
+| requests           | pysatNASA <= 0.0.4 |
+| scipy              |                    |
+| xarray             |                    |
 
 ## Installation through PyPi
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,8 +24,8 @@ the Space Physics community.  This module officially supports Python 3.6+.
  Common modules Community modules
  ============== =================
   numpy         pysat
-  pandas        pyForecastTools
-  requests
+  pandas        pysatNASA
+  requests      pyForecastTools
   scipy
   xarray
  ============== =================
@@ -85,7 +85,7 @@ is set up, you may choose to register the the :py:mod:`pysatModel` model
 
 .. code:: python
 
-	  
+
    import pysat
    import pysatModels as pymod
 

--- a/pysatModels/tests/test_methods_general.py
+++ b/pysatModels/tests/test_methods_general.py
@@ -14,7 +14,7 @@ from pysatModels.models.methods import general
 class TestMethodsGeneralLogging(object):
     """Unit tests for log messages raised by general methods."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment."""
         self.ch = logging.StreamHandler()
         self.ch.setLevel(logging.INFO)
@@ -22,7 +22,7 @@ class TestMethodsGeneralLogging(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment."""
 
         del self.ch, self.model
@@ -50,7 +50,7 @@ class TestMethodsGeneralLogging(object):
 class TestMethodsGeneralDownload(object):
     """Unit tests for general methods handling downloads."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment."""
         # TODO(#100): remove if-statement when it is always triggered
         tkwargs = {}
@@ -65,7 +65,7 @@ class TestMethodsGeneralDownload(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment."""
 
         if os.path.isfile(self.out_file):

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -14,77 +14,26 @@ import shutil
 import sys
 import tempfile
 
+# Import the test classes from pysat
 import pysat
-from pysat.tests.instrument_test_class import InstTestClass
+from pysat.tests.classes import cls_instrument_library as clslib
 
 import pysatModels
 
 # Retrieve the lists of Model instruments and testing methods
-instruments = pysat.utils.generate_instrument_list(inst_loc=pysatModels.models)
-method_list = [func for func in dir(InstTestClass)
-               if callable(getattr(InstTestClass, func))]
-
-# Search tests for iteration via pytestmark, update instrument list
-for method in method_list:
-    if hasattr(getattr(InstTestClass, method), 'pytestmark'):
-        # Get list of names of pytestmarks
-        mark_name = [mod_mark.name for mod_mark
-                     in getattr(InstTestClass, method).pytestmark]
-
-        # Add instruments from your library
-        if 'all_inst' in mark_name:
-            mark = pytest.mark.parametrize("inst_name", instruments['names'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
-        elif 'download' in mark_name:
-            mark = pytest.mark.parametrize("inst_dict",
-                                           instruments['download'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
-        elif 'no_download' in mark_name:
-            mark = pytest.mark.parametrize("inst_dict",
-                                           instruments['no_download'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
+instruments = clslib.InstLibTests.initialize_test_package(
+    clslib.InstLibTests, inst_loc=pysatModels.models)
 
 
-class TestModels(InstTestClass):
+class TestModels(clslib.InstLibTests):
     """Main class for instrument tests.
 
     Note
     ----
-    Uses class level setup and teardown so that all tests use the same
-    temporary directory. We do not want to geneate a new tempdir for each test,
-    as the load tests need to be the same as the download tests.
+    All standard tests, setup, and teardown inherited from the core pysat
+    instrument test class.
 
     """
-
-    def setup_class(self):
-        """Initialize the testing setup once before all tests are run."""
-        # Make sure to use a temporary directory so that the user setup is not
-        # altered
-        # TODO(#100): remove if-statement when it is always triggered
-        tkwargs = {}
-        if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
-            tkwargs = {"ignore_cleanup_errors": True}
-        self.tempdir = tempfile.TemporaryDirectory(**tkwargs)
-        self.saved_path = pysat.params['data_dirs']
-        pysat.params.data['data_dirs'] = [self.tempdir.name]
-
-        # Assign the location of the model Instrument sub-modules
-        self.inst_loc = pysatModels.models
-        return
-
-    def teardown_class(self):
-        """Clean up downloaded files and parameters from tests."""
-
-        pysat.params.data['data_dirs'] = self.saved_path
-
-        # TODO(#100): Remove try/except when Python 3.10 is the lowest version
-        try:
-            self.tempdir.cleanup()
-        except Exception:
-            pass
-
-        del self.inst_loc, self.saved_path, self.tempdir
-        return
 
 
 class TestSAMIPysatVersion(object):

--- a/pysatModels/tests/test_utils_convert.py
+++ b/pysatModels/tests/test_utils_convert.py
@@ -64,7 +64,7 @@ def eval_xarray_output(inst, xdata):
 class TestUtilsConvertLoadModelXarray(object):
     """Unit tests for `utils.convert.load_model_xarray`."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
         self.ftime = pysat.instruments.pysat_testing_xarray._test_dates['']['']
         self.filename = "%Y-%m-%d.nofile"
@@ -76,7 +76,7 @@ class TestUtilsConvertLoadModelXarray(object):
         self.xout = None
         self.temp_file = 'None'
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up test environment after each method."""
         if os.path.isfile(self.temp_file):
             os.remove(self.temp_file)
@@ -130,11 +130,11 @@ class TestUtilsConvertLoadModelXarray(object):
 class TestUtilsConvertPysatXarray(object):
     """Unit tests for utils.convert.convert_pysat_to_xarray."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup before each method."""
         self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up test environment after each method."""
         del self.ref_time
 

--- a/pysatModels/tests/test_utils_extract.py
+++ b/pysatModels/tests/test_utils_extract.py
@@ -20,7 +20,7 @@ import pysatModels.utils.extract as extract
 class TestUtilsExtractInstThroughMod(object):
     """Unit tests for `instrument_view_through_model`."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
         self.inst = pysat.Instrument(platform='pysat', name='testing')
@@ -51,7 +51,7 @@ class TestUtilsExtractInstThroughMod(object):
         self.out = []
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment after each method."""
 
         del self.inst, self.model, self.input_args, self.out, self.input_kwargs
@@ -205,7 +205,7 @@ class TestUtilsExtractInstThroughMod(object):
 class TestUtilsExtractModObs(TestUtilsExtractInstThroughMod):
     """Unit tests for `utils.extract.extract_modelled_observations`."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
         self.inst = pysat.Instrument(platform='pysat', name='testing')
@@ -233,7 +233,7 @@ class TestUtilsExtractModObs(TestUtilsExtractInstThroughMod):
         self.out = []
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment after each method."""
 
         del self.inst, self.model, self.input_args, self.out, self.input_kwargs
@@ -351,7 +351,7 @@ class TestUtilsExtractModObs(TestUtilsExtractInstThroughMod):
 class TestUtilsExtractModObsXarray(TestUtilsExtractModObs):
     """Xarray unit tests for `utils.extract.extract_modelled_observations`."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
         self.inst = pysat.Instrument(platform='pysat', name='testing_xarray')
@@ -379,7 +379,7 @@ class TestUtilsExtractModObsXarray(TestUtilsExtractModObs):
         self.out = []
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment after each method."""
 
         del self.inst, self.model, self.input_args, self.out, self.input_kwargs
@@ -393,7 +393,7 @@ class TestUtilsExtractModObsXarray(TestUtilsExtractModObs):
 class TestUtilsExtractModObsXarray2D(TestUtilsExtractModObs):
     """Xarray unit tests for `utils.extract.extract_modelled_observations`."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
         self.inst = pysat.Instrument(platform='pysat', name='testing2d_xarray')
@@ -421,7 +421,7 @@ class TestUtilsExtractModObsXarray2D(TestUtilsExtractModObs):
         self.out = []
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment after each method."""
 
         del self.inst, self.model, self.input_args, self.out, self.input_kwargs
@@ -431,7 +431,7 @@ class TestUtilsExtractModObsXarray2D(TestUtilsExtractModObs):
 class TestUtilsExtractInstModViewXarray(TestUtilsExtractInstThroughMod):
     """Xarray unit tests for `instrument_view_through_model`."""
 
-    def setup(self):
+    def setup_method(self):
         """Run before every method to create a clean testing setup."""
 
         self.inst = pysat.Instrument(platform='pysat', name='testing2d_xarray')
@@ -464,7 +464,7 @@ class TestUtilsExtractInstModViewXarray(TestUtilsExtractInstThroughMod):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Run after every method to clean up previous testing."""
 
         del self.inst, self.model, self.input_args, self.out, self.input_kwargs
@@ -482,7 +482,7 @@ class TestUtilsExtractInstModViewXarray(TestUtilsExtractInstThroughMod):
 class TestUtilsAltitudePressure(object):
     """Unit tests for `utils.extract.instrument_altitude_to_model_pressure`."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
         self.inst = pysat.Instrument(platform='pysat', name='testing')
@@ -509,7 +509,7 @@ class TestUtilsAltitudePressure(object):
         self.out = []
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment after each method."""
 
         del self.inst, self.model, self.input_args, self.out
@@ -618,7 +618,7 @@ class TestUtilsAltitudePressure(object):
 class TestUtilsAltitudePressureXarray(TestUtilsAltitudePressure):
     """Xarray unit tests for `instrument_altitude_to_model_pressure`."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
         self.inst = pysat.Instrument(platform='pysat', name='testing2d_xarray')
@@ -645,7 +645,7 @@ class TestUtilsAltitudePressureXarray(TestUtilsAltitudePressure):
         self.out = []
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment after each method."""
 
         del self.inst, self.model, self.input_args, self.out
@@ -660,7 +660,7 @@ class TestUtilsAltitudePressureXarray(TestUtilsAltitudePressure):
 class TestUtilsExtractInstModIrregView(object):
     """Unit tests for `utils.extract.instrument_view_irregular_model`."""
 
-    def setup(self):
+    def setup_method(self):
         """Run before every method to create a clean testing setup."""
 
         self.inst = pysat.Instrument(platform='pysat', name='testing',
@@ -689,7 +689,7 @@ class TestUtilsExtractInstModIrregView(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Run after every method to clean up previous testing."""
 
         del self.inst, self.model, self.input_args, self.out, self.in_kwargs
@@ -773,7 +773,7 @@ class TestUtilsExtractInstModIrregView(object):
 class TestUtilsExtractInstModIrregViewXarray(TestUtilsExtractInstModIrregView):
     """Xarray unit tests for `instrument_view_irregular_model`."""
 
-    def setup(self):
+    def setup_method(self):
         """Run before every method to create a clean testing setup."""
 
         self.inst = pysat.Instrument(platform='pysat', name='testing2d_xarray',
@@ -802,7 +802,7 @@ class TestUtilsExtractInstModIrregViewXarray(TestUtilsExtractInstModIrregView):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Run after every method to clean up previous testing."""
 
         del self.inst, self.model, self.input_args, self.out, self.in_kwargs

--- a/pysatModels/tests/test_utils_testing.py
+++ b/pysatModels/tests/test_utils_testing.py
@@ -18,7 +18,7 @@ from pysatModels.utils.testing import compare_mod_name_coordinates
 class TestUtilsCompareModName(object):
     """Unit tests for `compare_mod_name_coordinates`."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
         self.model = pysat.Instrument(inst_module=pysat_testmodel, tag='')
@@ -33,7 +33,7 @@ class TestUtilsCompareModName(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up the unit test environment after each method."""
 
         del self.model
@@ -99,7 +99,7 @@ class TestUtilsCompareModName(object):
 class TestUtilsCompareModNamePressure(TestUtilsCompareModName):
     """Unit tests for `compare_mod_name_coordinates`."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the unit test environment for each method."""
 
         self.model = pysat.Instrument(inst_module=pysat_testmodel,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ packaging
 pandas >= 1.4.0
 pyForecastTools
 pysat >= 3.0.4
-pysatNASA
+pysatNASA <= 0.0.4
 requests
 scipy
 xarray


### PR DESCRIPTION
# Description

Addresses #127, pysat roadmap

Updates pytest standards by removing `nose` syntax, which will be removed in a future version.

Also updates the instrument test class usage, which will be updated in pysat 3.2.0.

The line  "Updated tests to new pysat and pytest standards" in the changelog seems to describe these changes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Via github actions and locally using pytest

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.10.9
* Any details about your local setup that are relevant: pysat version https://github.com/pysat/pysat/pull/1143

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
