### PR TITLE
MAINT: backward compatibility for pysat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added manual test for pysatModels RC pip install
   * Updated tests to new pysat and pytest standards
   * Added a cap for pysatNASA
+  * Removed backwards-support for pysat pre-3.0.4 functions
 * Documentation
   * Added badges and instructions for PyPi and Zenodo
 

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -149,10 +149,10 @@ def load(fnames, tag='', inst_id='', **kwargs):
     loaded_meta = []
     for epoch, fname in zip(epochs, fnames):
         # Load data
-        data, meta = pysat.utils.load_netcdf4([fname], pandas_format=False,
-                                              epoch_name='ut',
-                                              epoch_origin=epoch,
-                                              epoch_unit='h')
+        data, meta = pysat.utils.io.load_netcdf([fname], pandas_format=False,
+                                                epoch_name='ut',
+                                                epoch_origin=epoch,
+                                                epoch_unit='h')
 
         # Store data/meta for each loop
         loaded_data.append(data)

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -23,7 +23,6 @@ inst_id
 
 import datetime as dt
 import functools
-from packaging import version as pack_version
 import warnings
 import xarray as xr
 
@@ -146,26 +145,14 @@ def load(fnames, tag='', inst_id='', **kwargs):
                                 file_info['day']):
         epochs.append(dt.datetime(year, month, day))
 
-    vstr = '3.0.2'  # TODO(#112) Remove support for backwards compatibility
     loaded_data = []
     loaded_meta = []
     for epoch, fname in zip(epochs, fnames):
         # Load data
-        # TODO(#112) Remove backwards compatibility
-        if pack_version.Version(pysat.__version__) < pack_version.Version(vstr):
-            data, meta = pysat.utils.load_netcdf4([fname], pandas_format=False,
-                                                  epoch_name='ut')
-            data = data.rename({"ut": "time"})
-
-            # Create datetimes from 'ut' variable
-            data['time'] = [epoch
-                            + dt.timedelta(seconds=int(val * 3600.0))
-                            for val in data['time'].values]
-        else:
-            data, meta = pysat.utils.load_netcdf4([fname], pandas_format=False,
-                                                  epoch_name='ut',
-                                                  epoch_origin=epoch,
-                                                  epoch_unit='h')
+        data, meta = pysat.utils.load_netcdf4([fname], pandas_format=False,
+                                              epoch_name='ut',
+                                              epoch_origin=epoch,
+                                              epoch_unit='h')
 
         # Store data/meta for each loop
         loaded_data.append(data)

--- a/pysatModels/models/ucar_tiegcm.py
+++ b/pysatModels/models/ucar_tiegcm.py
@@ -185,13 +185,9 @@ def load(fnames, tag='', inst_id='', **kwargs):
 
     """
 
-    # TODO(#114): eventually remove support for multiple pysat versions
-    if hasattr(pysat.utils, 'io'):
-        data, meta = pysat.utils.io.load_netcdf(fnames, pandas_format=False,
-                                                epoch_name='time',
-                                                decode_times=True)
-    else:
-        data, meta = pysat.utils.load_netcdf4(fnames, pandas_format=False)
+    data, meta = pysat.utils.io.load_netcdf(fnames, pandas_format=False,
+                                            epoch_name='time',
+                                            decode_times=True)
 
     # Move misc parameters from xarray to the Instrument object via Meta.
     # Doing this after `meta` created ensures all metadata is still kept

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -8,8 +8,6 @@ Imports test methods from pysat.tests.instrument_test_class
 
 import datetime as dt
 import os
-from packaging import version as pack_version
-import pytest
 import shutil
 import sys
 import tempfile
@@ -34,81 +32,6 @@ class TestModels(clslib.InstLibTests):
     instrument test class.
 
     """
-
-
-class TestSAMIPysatVersion(object):
-    """Test SAMI load code for pysat version differences across v3.0.2."""
-
-    def setup_class(self):
-        """Initialize the testing setup once before all tests are run."""
-        # Make sure to use a temporary directory so that the user setup is not
-        # altered
-
-        # TODO(#100): remove if-statement when it is always triggered
-        tkwargs = {}
-        if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
-            tkwargs = {"ignore_cleanup_errors": True}
-        self.tempdir = tempfile.TemporaryDirectory(**tkwargs)
-        self.saved_path = pysat.params['data_dirs']
-        self.saved_ver = pysat.__version__
-        pysat.params.data['data_dirs'] = [self.tempdir.name]
-
-        # Assign the location of the model Instrument sub-modules
-        self.inst_loc = pysatModels.models
-        return
-
-    def teardown_class(self):
-        """Clean up downloaded files and parameters from tests."""
-
-        pysat.params.data['data_dirs'] = self.saved_path
-        pysat.__version__ = self.saved_ver
-
-        # Remove the temporary directory
-        # TODO(#100): Remove try/except when Python 3.10 is the lowest version
-        try:
-            self.tempdir.cleanup()
-        except Exception:
-            pass
-
-        del self.inst_loc, self.saved_path, self.tempdir, self.saved_ver
-        return
-
-    def test_load_failure(self):
-        """Test for SAMI load failure when faking a different pysat version."""
-
-        if (pack_version.Version(pysat.__version__)
-                >= pack_version.Version('3.0.2')):
-            # Define target error variable label
-            label = 'ut'
-
-            # Replace reported version with one before 3.0.2
-            vlabel = '3.0.1'
-
-            # Expected error
-            error = ValueError
-        else:
-            # Define target error variable label
-            label = 'epoch_origin'
-
-            # Expected error
-            error = TypeError
-
-            # Replace reported version with one including 3.0.2
-            vlabel = '3.0.2'
-
-        # Update reported pysat version
-        pysat.__version__ = vlabel
-
-        with pytest.raises(error) as verr:
-            inst = pysat.Instrument(inst_module=self.inst_loc.sami2py_sami2,
-                                    tag='test')
-            inst.download(self.inst_loc.sami2py_sami2._test_dates['']['test'],
-                          self.inst_loc.sami2py_sami2._test_dates['']['test'])
-            inst.load(date=self.inst_loc.sami2py_sami2._test_dates['']['test'])
-
-        assert str(verr).find(label) >= 0
-
-        return
 
 
 class TestSAMILoadMultipleDays(object):

--- a/pysatModels/tests/test_utils_extract.py
+++ b/pysatModels/tests/test_utils_extract.py
@@ -7,7 +7,6 @@
 
 import logging
 import numpy as np
-from packaging import version as pack_version
 import platform
 import pytest
 
@@ -28,9 +27,7 @@ class TestUtilsExtractInstThroughMod(object):
 
         # Load the data in the instruments
         load_kwargs = {'date': pysat_testmodel._test_dates['']['']}
-        if(pack_version.Version(pysat.__version__)
-           > pack_version.Version('3.0.1')):
-            load_kwargs['use_header'] = True
+        load_kwargs['use_header'] = True
 
         self.inst.load(**load_kwargs)
         self.model.load(**load_kwargs)
@@ -198,10 +195,6 @@ class TestUtilsExtractInstThroughMod(object):
         return
 
 
-@pytest.mark.skipif(pack_version.Version(pysat.__version__)
-                    <= pack_version.Version('3.0.1'),
-                    reason=''.join(('Requires test model in pysat ',
-                                    ' v3.0.2 or later.')))
 class TestUtilsExtractModObs(TestUtilsExtractInstThroughMod):
     """Unit tests for `utils.extract.extract_modelled_observations`."""
 
@@ -213,9 +206,7 @@ class TestUtilsExtractModObs(TestUtilsExtractInstThroughMod):
 
         # Load the data in the instruments
         load_kwargs = {'date': pysat_testmodel._test_dates['']['']}
-        if(pack_version.Version(pysat.__version__)
-           > pack_version.Version('3.0.1')):
-            load_kwargs['use_header'] = True
+        load_kwargs['use_header'] = True
 
         self.inst.load(**load_kwargs)
         self.model.load(**load_kwargs)
@@ -344,10 +335,6 @@ class TestUtilsExtractModObs(TestUtilsExtractInstThroughMod):
         return
 
 
-@pytest.mark.skipif(pack_version.Version(pysat.__version__)
-                    <= pack_version.Version('3.0.1'),
-                    reason=''.join(('Requires test model in pysat ',
-                                    ' v3.0.2 or later.')))
 class TestUtilsExtractModObsXarray(TestUtilsExtractModObs):
     """Xarray unit tests for `utils.extract.extract_modelled_observations`."""
 
@@ -359,9 +346,7 @@ class TestUtilsExtractModObsXarray(TestUtilsExtractModObs):
 
         # Load the data in the instruments
         load_kwargs = {'date': pysat_testmodel._test_dates['']['']}
-        if(pack_version.Version(pysat.__version__)
-           > pack_version.Version('3.0.1')):
-            load_kwargs['use_header'] = True
+        load_kwargs['use_header'] = True
 
         self.inst.load(**load_kwargs)
         self.model.load(**load_kwargs)
@@ -386,10 +371,6 @@ class TestUtilsExtractModObsXarray(TestUtilsExtractModObs):
         return
 
 
-@pytest.mark.skipif(pack_version.Version(pysat.__version__)
-                    <= pack_version.Version('3.0.1'),
-                    reason=''.join(('Requires test model in pysat ',
-                                    ' v3.0.2 or later.')))
 class TestUtilsExtractModObsXarray2D(TestUtilsExtractModObs):
     """Xarray unit tests for `utils.extract.extract_modelled_observations`."""
 
@@ -401,9 +382,7 @@ class TestUtilsExtractModObsXarray2D(TestUtilsExtractModObs):
 
         # Load the data in the instruments
         load_kwargs = {'date': pysat_testmodel._test_dates['']['']}
-        if(pack_version.Version(pysat.__version__)
-           > pack_version.Version('3.0.1')):
-            load_kwargs['use_header'] = True
+        load_kwargs['use_header'] = True
 
         self.inst.load(**load_kwargs)
         self.model.load(**load_kwargs)
@@ -439,9 +418,7 @@ class TestUtilsExtractInstModViewXarray(TestUtilsExtractInstThroughMod):
 
         # Load the data in the instruments
         load_kwargs = {'date': pysat_testmodel._test_dates['']['']}
-        if(pack_version.Version(pysat.__version__)
-           > pack_version.Version('3.0.1')):
-            load_kwargs['use_header'] = True
+        load_kwargs['use_header'] = True
 
         self.inst.load(**load_kwargs)
         self.model.load(**load_kwargs)
@@ -475,10 +452,6 @@ class TestUtilsExtractInstModViewXarray(TestUtilsExtractInstThroughMod):
 # TODO(#118): fix `instrument_altitude_to_model_pressure` for Windows env
 @pytest.mark.skipif(platform.system() == "Windows",
                     reason="Broken on windows, see #118")
-@pytest.mark.skipif(pack_version.Version(pysat.__version__)
-                    <= pack_version.Version('3.0.1'),
-                    reason=''.join(('Requires test model in pysat ',
-                                    ' v3.0.2 or later.')))
 class TestUtilsAltitudePressure(object):
     """Unit tests for `utils.extract.instrument_altitude_to_model_pressure`."""
 
@@ -491,9 +464,7 @@ class TestUtilsAltitudePressure(object):
 
         # Load the data in the instruments
         load_kwargs = {'date': pysat_testmodel._test_dates['']['']}
-        if(pack_version.Version(pysat.__version__)
-           > pack_version.Version('3.0.1')):
-            load_kwargs['use_header'] = True
+        load_kwargs['use_header'] = True
 
         self.inst.load(**load_kwargs)
         self.model.load(**load_kwargs)
@@ -611,10 +582,6 @@ class TestUtilsAltitudePressure(object):
 # TODO(#118): fix `instrument_altitude_to_model_pressure` for Windows env
 @pytest.mark.skipif(platform.system() == "Windows",
                     reason="Broken on windows, see #118")
-@pytest.mark.skipif(pack_version.Version(pysat.__version__)
-                    <= pack_version.Version('3.0.1'),
-                    reason=''.join(('Requires test model in pysat ',
-                                    ' v3.0.2 or later.')))
 class TestUtilsAltitudePressureXarray(TestUtilsAltitudePressure):
     """Xarray unit tests for `instrument_altitude_to_model_pressure`."""
 
@@ -627,9 +594,7 @@ class TestUtilsAltitudePressureXarray(TestUtilsAltitudePressure):
 
         # Load the data in the instruments
         load_kwargs = {'date': pysat_testmodel._test_dates['']['']}
-        if(pack_version.Version(pysat.__version__)
-           > pack_version.Version('3.0.1')):
-            load_kwargs['use_header'] = True
+        load_kwargs['use_header'] = True
 
         self.inst.load(**load_kwargs)
         self.model.load(**load_kwargs)
@@ -653,10 +618,6 @@ class TestUtilsAltitudePressureXarray(TestUtilsAltitudePressure):
         return
 
 
-@pytest.mark.skipif(pack_version.Version(pysat.__version__)
-                    <= pack_version.Version('3.0.1'),
-                    reason=''.join(('Requires `max_latitude` test Instrument ',
-                                    'support in pysat v3.0.2 or later.')))
 class TestUtilsExtractInstModIrregView(object):
     """Unit tests for `utils.extract.instrument_view_irregular_model`."""
 
@@ -671,9 +632,7 @@ class TestUtilsExtractInstModIrregView(object):
 
         # Load the data in the instruments
         load_kwargs = {'date': pysat_testmodel._test_dates['']['']}
-        if(pack_version.Version(pysat.__version__)
-           > pack_version.Version('3.0.1')):
-            load_kwargs['use_header'] = True
+        load_kwargs['use_header'] = True
 
         self.inst.load(**load_kwargs)
         self.model.load(**load_kwargs)
@@ -766,10 +725,6 @@ class TestUtilsExtractInstModIrregView(object):
         return
 
 
-@pytest.mark.skipif(pack_version.Version(pysat.__version__)
-                    <= pack_version.Version('3.0.1'),
-                    reason=''.join(('Requires `max_latitude` test Instrument ',
-                                    'support in pysat v3.0.2 or later.')))
 class TestUtilsExtractInstModIrregViewXarray(TestUtilsExtractInstModIrregView):
     """Xarray unit tests for `instrument_view_irregular_model`."""
 
@@ -784,9 +739,7 @@ class TestUtilsExtractInstModIrregViewXarray(TestUtilsExtractInstModIrregView):
 
         # Load the data in the instruments
         load_kwargs = {'date': pysat_testmodel._test_dates['']['']}
-        if(pack_version.Version(pysat.__version__)
-           > pack_version.Version('3.0.1')):
-            load_kwargs['use_header'] = True
+        load_kwargs['use_header'] = True
 
         self.inst.load(**load_kwargs)
         self.model.load(**load_kwargs)


### PR DESCRIPTION
# Description

Addresses #112, #114, #123

The requirements file no has a minimum version of pysat 3.0.4. 
- Removing if/else statements and tests for older version of pysat.
- Update location of `load_netcdf`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

pytest

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.10.9


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
